### PR TITLE
Update README with another way to download the data

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ With [git](https://git-scm.com/downloads) installed, you can download the datase
 git clone https://github.com/spMohanty/PlantVillage-Dataset
 cd PlantVillage-Dataset
 ```
+
+Or you can download specific folders through [svn](https://subversion.apache.org/) by replacing `<folderYouWant>` with the appropriate path:
+```
+svn checkout https://github.com/spMohanty/PlantVillage-Dataset/trunk/<folderYouWant>
+```
+For example, if you want to download the folder `raw/color/Grape___Esca_(Black_Measles)`, do it like so:
+```
+svn checkout https://github.com/spMohanty/PlantVillage-Dataset/trunk/raw/color/Grape___Esca_\(Black_Measles)
+```
+
+
+
 The different versions of the dataset are present in the `raw` directory : 
 * `color` : Original RGB images
 * `grayscale` : grayscaled version of the raw images


### PR DESCRIPTION
Adds example using `svn`, which allows to download specific folders instead of the whole repo.  Fixes #8 